### PR TITLE
Fix: Further refine header layout for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
                 </button>
                 <h1 class="text-xl sm:text-2xl md:text-3xl lg:text-4xl font-bold">Productivity Hub</h1>
                 <div class="absolute right-0 top-1/2 -translate-y-1/2"> <label for="themeSwitcher" class="sr-only">Select Theme</label>
-                    <select id="themeSwitcher" class="input-field p-2 rounded-md text-sm">
+                    <select id="themeSwitcher" class="input-field p-2 rounded-md text-sm w-28">
                         <option value="light">Light Theme</option>
                         <option value="dark">Dark Theme</option>
                         <option value="forest">Forest Theme</option>


### PR DESCRIPTION
This commit further addresses the overlap between the header title and the theme switcher button on specific mobile screen widths (around 360px-430px viewport width).

The previous fix (reducing title font size) was not sufficient for all cases. This commit introduces the following additional change:

1.  The theme switcher `<select>` element now has a fixed width of `w-28` (7rem / 112px) using Tailwind CSS. This prevents the select element from rendering too widely based on its option text or browser defaults.

Combined with the earlier change of setting the base title font size to `text-xl`, this ensures adequate spacing between the title and the side buttons (info and theme switcher) on narrow viewports.